### PR TITLE
Improve notification behaviors

### DIFF
--- a/src/main/kotlin/nya/kitsunyan/foxydroid/screen/ScreenActivity.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/screen/ScreenActivity.kt
@@ -77,7 +77,7 @@ abstract class ScreenActivity: FragmentActivity() {
 
     // Modified by REV Robotics on 2021-05-10: Sync repositories when activity is created
     Connection(SyncService::class.java, onBind = { connection, binder ->
-      binder.sync(SyncService.SyncRequest.MANUAL)
+      binder.sync(SyncService.SyncRequest.AUTO)
       connection.unbind(this)
     }).bind(this)
 

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/service/SyncService.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/service/SyncService.kt
@@ -312,9 +312,11 @@ class SyncService: ConnectionService<SyncService.Binder>() {
               if (throwable != null && task.manual) {
                 showNotificationError(repository, throwable as Exception)
               }
-              // Added by REV Robotics: Mark the repo as having been just downloaded
               if (throwable == null) {
+                // Added by REV Robotics on 2021-04-29: Mark the repo as having been just downloaded
                 ProductsFragment.markRepoAsJustDownloaded(repository.id)
+                // Added by REV Robotics on 2021-06-02: Clear any existing error notification for this repository
+                notificationManager.cancel("repository-${repository.id}", Common.NOTIFICATION_ID_SYNCING)
               }
               handleNextTask(result == true || hasUpdates)
             }


### PR DESCRIPTION
* Don't show an error notification when the user launches the app and the automatic repository sync fails
* Clear any "X repository sync failed" notification when that repository syncs successfully