### PR TITLE
Add build flavor that adds an option to show all tabs and enable other repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,19 @@ android {
       }
     }
   }
+
+  // Flavor configuration added by REV Robotics on 2021-06-06
+  flavorDimensions "tabs"
+  productFlavors {
+    create("allTabsCanBeEnabled") {
+      dimension = "tabs"
+      buildConfigField('boolean', 'ALL_TABS_CAN_BE_ENABLED', 'true')
+    }
+    create("onlyUpdatesTab") {
+      dimension = "tabs"
+      buildConfigField('boolean', 'ALL_TABS_CAN_BE_ENABLED', 'false')
+    }
+  }
 }
 
 repositories {

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/content/Preferences.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/content/Preferences.kt
@@ -16,7 +16,7 @@ object Preferences {
   private val subject = PublishSubject.create<Key<*>>()
 
   private val keys = sequenceOf(Key.AutoSync, Key.IncompatibleVersions, Key.ProxyHost, Key.ProxyPort, Key.ProxyType,
-    Key.SortOrder, Key.Theme, Key.UpdateNotify, Key.UpdateUnstable).map { Pair(it.name, it) }.toMap()
+    Key.ShowAllTabs, Key.SortOrder, Key.Theme, Key.UpdateNotify, Key.UpdateUnstable).map { Pair(it.name, it) }.toMap()
 
   fun init(context: Context) {
     preferences = context.getSharedPreferences("${context.packageName}_preferences", Context.MODE_PRIVATE)
@@ -85,6 +85,7 @@ object Preferences {
     object ProxyHost: Key<String>("proxy_host", Value.StringValue("localhost"))
     object ProxyPort: Key<Int>("proxy_port", Value.IntValue(9050))
     object ProxyType: Key<Preferences.ProxyType>("proxy_type", Value.EnumerationValue(Preferences.ProxyType.Direct))
+    object ShowAllTabs: Key<Boolean>("show_all_tabs", Value.BooleanValue(false))
     object SortOrder: Key<Preferences.SortOrder>("sort_order", Value.EnumerationValue(Preferences.SortOrder.Update))
     object Theme: Key<Preferences.Theme>("theme", Value.EnumerationValue(if (Android.sdk(29))
       Preferences.Theme.System else Preferences.Theme.Light))

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/screen/PreferencesFragment.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/screen/PreferencesFragment.kt
@@ -20,6 +20,7 @@ import android.widget.Toolbar
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import io.reactivex.rxjava3.disposables.Disposable
+import nya.kitsunyan.foxydroid.BuildConfig
 import nya.kitsunyan.foxydroid.R
 import nya.kitsunyan.foxydroid.content.Preferences
 import nya.kitsunyan.foxydroid.utility.extension.resources.*
@@ -84,7 +85,9 @@ class PreferencesFragment: ScreenFragment() {
       }
       addSwitch(Preferences.Key.IncompatibleVersions, getString(R.string.incompatible_versions),
         getString(R.string.incompatible_versions_summary))
-      addSwitch(Preferences.Key.ShowAllTabs, "Show all tabs", "Show \"Available\" and \"Installed\" tabs")
+      if (BuildConfig.ALL_TABS_CAN_BE_ENABLED) {
+        addSwitch(Preferences.Key.ShowAllTabs, "Show all tabs", "Show \"Available\" and \"Installed\" tabs")
+      }
     }
 
     disposable = Preferences.observable.subscribe(this::updatePreference)

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/screen/PreferencesFragment.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/screen/PreferencesFragment.kt
@@ -84,6 +84,7 @@ class PreferencesFragment: ScreenFragment() {
       }
       addSwitch(Preferences.Key.IncompatibleVersions, getString(R.string.incompatible_versions),
         getString(R.string.incompatible_versions_summary))
+      addSwitch(Preferences.Key.ShowAllTabs, "Show all tabs", "Show \"Available\" and \"Installed\" tabs")
     }
 
     disposable = Preferences.observable.subscribe(this::updatePreference)

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/screen/TabsFragment.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/screen/TabsFragment.kt
@@ -91,7 +91,7 @@ class TabsFragment: ScreenFragment() {
   // Added by REV Robotics on 2021-04-08 to allow only a single tab to be selected.
   // All other references to ProductsFragment.Source.values() in this file should probably be
   // replaced with a reference to selectableTabs.
-  private val showAllTabs = false
+  private val showAllTabs = Preferences[Preferences.Key.ShowAllTabs]
   private val selectableTabs = if (showAllTabs) {
     ProductsFragment.Source.values()
   } else {
@@ -192,11 +192,13 @@ class TabsFragment: ScreenFragment() {
         }
 
       // Repositories menu option disabled by REV Robotics on 2021-05-04
-      /*add(1, 0, 0, R.string.repositories)
-        .setOnMenuItemClickListener {
-          view.post { screenActivity.navigateRepositories() }
-          true
-        }*/
+      if (Preferences[Preferences.Key.ShowAllTabs]) {
+        add(1, 0, 0, R.string.repositories)
+            .setOnMenuItemClickListener {
+              view.post { screenActivity.navigateRepositories() }
+              true
+            }
+      }
 
       add(1, 0, 0, R.string.preferences)
         .setOnMenuItemClickListener {

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/screen/TabsFragment.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/screen/TabsFragment.kt
@@ -31,6 +31,7 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import nya.kitsunyan.foxydroid.BuildConfig
 import nya.kitsunyan.foxydroid.R
 import nya.kitsunyan.foxydroid.content.Preferences
 import nya.kitsunyan.foxydroid.database.Database
@@ -91,7 +92,7 @@ class TabsFragment: ScreenFragment() {
   // Added by REV Robotics on 2021-04-08 to allow only a single tab to be selected.
   // All other references to ProductsFragment.Source.values() in this file should probably be
   // replaced with a reference to selectableTabs.
-  private val showAllTabs = Preferences[Preferences.Key.ShowAllTabs]
+  private val showAllTabs = BuildConfig.ALL_TABS_CAN_BE_ENABLED && Preferences[Preferences.Key.ShowAllTabs]
   private val selectableTabs = if (showAllTabs) {
     ProductsFragment.Source.values()
   } else {
@@ -192,7 +193,7 @@ class TabsFragment: ScreenFragment() {
         }
 
       // Repositories menu option disabled by REV Robotics on 2021-05-04
-      if (Preferences[Preferences.Key.ShowAllTabs]) {
+      if (showAllTabs) {
         add(1, 0, 0, R.string.repositories)
             .setOnMenuItemClickListener {
               view.post { screenActivity.navigateRepositories() }


### PR DESCRIPTION
For now we're not exposing this option to users, but the ability to install apps from the f-droid.org repository is very useful for testing things.