### PR TITLE
Track relevant notification dismissals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
-    android: '3.4.1',
-    kotlin: '1.3.72'
+    android: '4.1.1',
+    kotlin: '1.4.32'
   ]
 
   repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -32,6 +32,8 @@
       </intent-filter>
 
     </receiver>
+
+    <receiver android:name=".MainApplication$NotificationDismissedReceiver" />
     
     <receiver android:name="com.revrobotics.InternetAvailableBroadcastReceiver">
       <intent-filter>

--- a/src/main/kotlin/com/revrobotics/RevConstants.kt
+++ b/src/main/kotlin/com/revrobotics/RevConstants.kt
@@ -18,10 +18,15 @@ object RevConstants {
 
   const val NOTIF_GROUP_SYNC_FAILED = "syncFailed"
 
+  const val EXTRA_DISMISSED_NOTIF_ID = "notificationId"
+  const val EXTRA_DISMISSED_NOTIF_UPDATES_LIST = "updatesList"
+
   val SHARED_PREFS: SharedPreferences = MainApplication.instance.getSharedPreferences("revrobotics", Context.MODE_PRIVATE)
 
   private const val PREF_AUTO_INSTALL_OS_ON_NEXT_LAUNCH = "autoInstallOsOnNextLaunch"
   private const val PREF_AUTO_INSTALL_OS_WHEN_DOWNLOAD_COMPLETES = "autoInstallOsWhenDownloadCompletes"
+  private const val PREF_DISMISSED_UPDATE_NOTIFICATION_PACKAGES = "dismissedUpdateNotificationPackages"
+  private const val PREF_USER_DISMISSED_STALE_REPOS_NOTIFICATION = "userDismissedStaleReposNotification"
 
   var shouldAutoInstallOSWhenDownloadCompletes: Boolean
     get() {
@@ -37,5 +42,26 @@ object RevConstants {
     }
     set(value) {
       SHARED_PREFS.edit().putBoolean(PREF_AUTO_INSTALL_OS_ON_NEXT_LAUNCH, value).apply()
+    }
+
+  /**
+   * The packages that were displayed in the update notification at the time it was dismissed.
+   *
+   * An empty list indicates that the update notification has not been dismissed since the last boot.
+   */
+  var dismissedUpdateNotificationPackages: Set<String>
+    get() {
+      return SHARED_PREFS.getStringSet(PREF_DISMISSED_UPDATE_NOTIFICATION_PACKAGES, emptySet())?.toSet().orEmpty()
+    }
+    set(value) {
+      SHARED_PREFS.edit().putStringSet(PREF_DISMISSED_UPDATE_NOTIFICATION_PACKAGES, value).apply()
+    }
+
+  var userDismissedStaleReposNotification: Boolean
+    get() {
+      return SHARED_PREFS.getBoolean(PREF_USER_DISMISSED_STALE_REPOS_NOTIFICATION, false)
+    }
+    set(value) {
+      SHARED_PREFS.edit().putBoolean(PREF_USER_DISMISSED_STALE_REPOS_NOTIFICATION, value).apply()
     }
 }

--- a/src/main/kotlin/com/revrobotics/Util.kt
+++ b/src/main/kotlin/com/revrobotics/Util.kt
@@ -154,6 +154,7 @@ object LastUpdateOfAllReposTracker {
 
     if (updated) {
       if (!reposAreVeryStale) {
+        RevConstants.userDismissedStaleReposNotification = false // If the repos go stale again, we want the notification to show up
         dismissStaleReposNotification()
       }
 
@@ -175,6 +176,7 @@ object LastUpdateOfAllReposTracker {
  */
 fun displayStaleReposNotification() {
   dismissUpdatesNotification()
+  RevConstants.userDismissedStaleReposNotification = false
   NotificationChannel(RevConstants.NOTIF_CHANNEL_STALE_REPOS,
       "Check for update reminders", NotificationManager.IMPORTANCE_DEFAULT)
       .apply { lockscreenVisibility = Notification.VISIBILITY_PUBLIC }
@@ -183,7 +185,17 @@ fun displayStaleReposNotification() {
   val launchAppIntent = Intent(MainApplication.instance, MainActivity::class.java).apply {
     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
   }
-  val pendingIntent = PendingIntent.getActivity(MainApplication.instance, 0, launchAppIntent, 0)
+  val launchAppPendingIntent = PendingIntent.getActivity(MainApplication.instance, 0, launchAppIntent, 0)
+
+  val notificationDismissedIntent = Intent(MainApplication.instance, MainApplication.NotificationDismissedReceiver::class.java)
+      .apply {
+        putExtra(RevConstants.EXTRA_DISMISSED_NOTIF_ID, RevConstants.NOTIF_ID_STALE_REPOS)
+      }
+  val notificationDismissedPendingIntent = PendingIntent.getBroadcast(
+      MainApplication.instance,
+      47926, // We just need to use a number that won't be used as a request code isn't used elsewhere.
+      notificationDismissedIntent,
+      PendingIntent.FLAG_UPDATE_CURRENT)
 
   val notification = NotificationCompat.Builder(MainApplication.instance, RevConstants.NOTIF_CHANNEL_STALE_REPOS)
       .setSmallIcon(R.drawable.ic_rev)
@@ -191,9 +203,10 @@ fun displayStaleReposNotification() {
       .setStyle(NotificationCompat.BigTextStyle()
           .bigText("Please connect to the Internet so that the Driver Hub can check for updates"))
       .setContentText("Please connect to the Internet so that the Driver Hub can check for updates")
-      .setContentIntent(pendingIntent)
+      .setContentIntent(launchAppPendingIntent)
       .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
       .setOnlyAlertOnce(true)
+      .setDeleteIntent(notificationDismissedPendingIntent)
       .build()
   NotificationManagerCompat.from(MainApplication.instance).notify(RevConstants.NOTIF_ID_STALE_REPOS, notification)
 }
@@ -210,6 +223,7 @@ fun durationOfWeeks(weeks: Long): Duration {
 // This function has been modified in subsequent commits
 fun displayUpdatesNotification(productItems: List<ProductItem>) {
   dismissStaleReposNotification() // The stale repos notification should only be displayed if no updates are available
+  RevConstants.dismissedUpdateNotificationPackages = emptySet() // Make sure this notification is marked as un-dismissed
 
   // For the Driver Hub Software Manager, we moved creation of the Updates notification channel to this function, since
   // this function may be called before the SyncService is created.
@@ -242,6 +256,16 @@ fun displayUpdatesNotification(productItems: List<ProductItem>) {
       updateAllIntent,
       PendingIntent.FLAG_UPDATE_CURRENT)
 
+  val notificationDismissedIntent = Intent(MainApplication.instance, MainApplication.NotificationDismissedReceiver::class.java)
+      .apply {
+        putExtra(RevConstants.EXTRA_DISMISSED_NOTIF_ID, Common.NOTIFICATION_ID_UPDATES)
+        putExtra(RevConstants.EXTRA_DISMISSED_NOTIF_UPDATES_LIST, productItems.map { it.packageName }.toTypedArray())
+      }
+  val notificationDismissedPendingIntent = PendingIntent.getBroadcast(
+      MainApplication.instance,
+      982518, // We just need to use a number that won't be used as a request code elsewhere.
+      notificationDismissedIntent,
+      PendingIntent.FLAG_UPDATE_CURRENT)
 
   fun <T> T.applyHack(callback: T.() -> Unit): T = apply(callback)
   notificationManager.notify(Common.NOTIFICATION_ID_UPDATES, NotificationCompat
@@ -272,6 +296,7 @@ fun displayUpdatesNotification(productItems: List<ProductItem>) {
       .setOnlyAlertOnce(true)
       .setVisibility(Notification.VISIBILITY_PUBLIC)
       .addAction(R.drawable.ic_launch, "Update All", updateAllPendingIntent)
+      .setDeleteIntent(notificationDismissedPendingIntent)
       .build())
 }
 

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/screen/ProductsFragment.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/screen/ProductsFragment.kt
@@ -299,7 +299,7 @@ class ProductsFragment(): ScreenFragment(), CursorOwner.Callback {
       }
       else -> {
         asOfPrefix + DateUtils.getRelativeTimeSpanString(lastUpdateOfAllRepos.toEpochMilli(), System.currentTimeMillis(), WEEK_IN_MILLIS) +
-            ".\n Please connect to the Internet and check for updates."
+            ".\n\nPlease connect to the Internet and check for updates."
       }
     }
     return getString(R.string.all_applications_up_to_date) + howLongAgo

--- a/src/main/kotlin/nya/kitsunyan/foxydroid/service/SyncService.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/service/SyncService.kt
@@ -12,7 +12,7 @@ import androidx.core.app.NotificationCompat
 import androidx.fragment.app.Fragment
 import com.revrobotics.LastUpdateOfAllReposTracker
 import com.revrobotics.RevConstants
-import com.revrobotics.displayUpdatesNotification
+import com.revrobotics.refreshUpdatesAndStaleReposNotifications
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
@@ -348,12 +348,9 @@ class SyncService: ConnectionService<SyncService.Binder>() {
               currentTask = null
               handleNextTask(false)
 
-              // Notification "blocked" logic removed by REV Robotics on 2021-06-06
-              // val blocked = updateNotificationBlockerFragment?.get()?.isAdded == true
+              // Modified by REV Robotics on 2021-06-09 to use shared notification logic
+              refreshUpdatesAndStaleReposNotifications(result)
 
-              if (/*!blocked &&*/ result != null && result.isNotEmpty()) {
-                displayUpdatesNotification(result)
-              }
             }
           currentTask = CurrentTask(null, disposable, true, State.Finishing)
         } else {


### PR DESCRIPTION
If the user dismisses the notification about stale repos, don't display that notification again until the device reboots, or the repos have been synced and have gone stale again.

If the user dismisses a notification about updates being available, don't display that notification again until the device reboots, or additional updates have become available.